### PR TITLE
Update types.js so that it is ES5 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - '0.12'
   - '4'
   - '6'
   - '8'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "array-find": "^1.0.0",
+    "array-find": "~1.0.0",
     "creditcards-types": "~2.0.0",
     "fast-luhn": "~1.0.1",
     "is-valid-month": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utility methods for formatting and validating credit cards",
   "main": "index.js",
   "scripts": {
-    "test": "standard && tape *.js | tap-difflet"
+    "test": "standard && tape *.js"
   },
   "repository": {
     "type": "git",
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/bendrucker/creditcards",
   "devDependencies": {
     "standard": "^8.0.0",
-    "tap-difflet": "^0.7.0",
     "tape": "^4.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
+    "array-find": "^1.0.0",
     "creditcards-types": "~2.0.0",
     "fast-luhn": "~1.0.1",
     "is-valid-month": "~1.0.0",

--- a/types.js
+++ b/types.js
@@ -12,9 +12,35 @@ function CardTypes (types) {
   }, {})
 
   return {
-    find: types.find.bind(types),
-    some: types.some.bind(types),
+    find: find,
+    some: some,
     get: get
+  }
+
+  function find (test) {
+    return types.reduce(
+      function (previous, current) {
+        if (previous !== null) {
+          return previous
+        }
+
+        if (test(current)) {
+          return current
+        } else {
+          return null
+        }
+      },
+      null
+    )
+  }
+
+  function some (test) {
+    return types.reduce(
+      function (previousValue, type) {
+        return test(type) || previousValue
+      },
+      false
+    )
   }
 
   function get (name) {

--- a/types.js
+++ b/types.js
@@ -13,7 +13,7 @@ function CardTypes (types) {
 
   return {
     find: find,
-    some: some,
+    some: types.some.bind(types),
     get: get
   }
 
@@ -31,15 +31,6 @@ function CardTypes (types) {
         }
       },
       null
-    )
-  }
-
-  function some (test) {
-    return types.reduce(
-      function (previousValue, type) {
-        return test(type) || previousValue
-      },
-      false
     )
   }
 

--- a/types.js
+++ b/types.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var arrayFind = require('array-find')
+var find = require('array-find')
 var defaults = require('creditcards-types')
 
 module.exports = CardTypes
@@ -13,13 +13,9 @@ function CardTypes (types) {
   }, {})
 
   return {
-    find: find,
+    find: find.bind(null, types),
     some: types.some.bind(types),
     get: get
-  }
-
-  function find (test) {
-    return arrayFind(types, test)
   }
 
   function get (name) {

--- a/types.js
+++ b/types.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var arrayFind = require('array-find')
 var defaults = require('creditcards-types')
 
 module.exports = CardTypes
@@ -18,20 +19,7 @@ function CardTypes (types) {
   }
 
   function find (test) {
-    return types.reduce(
-      function (previous, current) {
-        if (previous !== null) {
-          return previous
-        }
-
-        if (test(current)) {
-          return current
-        } else {
-          return null
-        }
-      },
-      null
-    )
+    return arrayFind(types, test)
   }
 
   function get (name) {


### PR DESCRIPTION
Hello! Thanks for a great library.

We are trying to use this library in IE (11), and we would like not to have to polyfill to be able to use it. This pull request reimplements `some` and `find` for the `CardTypes` so that they don’t rely on the ES6 browser implementation.

Let me know if this is something that works for you.