### PR TITLE
Convert to ESM-only with named exports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
 name: tests
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,5 +14,5 @@ jobs:
     strategy:
       matrix:
         node-version:
-        - "18"
         - "22"
+        - "24"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+package-lock.json

--- a/card-test.js
+++ b/card-test.js
@@ -1,66 +1,56 @@
-'use strict'
-
-const test = require('tape')
-const types = require('creditcards-types')
-const Card = require('./card')
-const visa = require('creditcards-types/types/visa')
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import types from 'creditcards-types'
+import visa from 'creditcards-types/types/visa'
+import Card from './card.js'
 
 const card = Card(types)
 
-test('card', function (t) {
-  t.test('parse', function (t) {
-    t.equal(card.parse('4242-4242-4242-4242'), '4242424242424242')
-    t.equal(card.parse('4242-4242-4242-4242'), '4242424242424242')
-    t.equal(card.parse(0), '')
-    t.equal(card.parse(undefined), '')
-    t.end()
+test('card', async (t) => {
+  await t.test('parse', () => {
+    assert.equal(card.parse('4242-4242-4242-4242'), '4242424242424242')
+    assert.equal(card.parse('4242-4242-4242-4242'), '4242424242424242')
+    assert.equal(card.parse(0), '')
+    assert.equal(card.parse(undefined), '')
   })
 
-  t.test('format', function (t) {
-    t.equal(card.format('5'), '5', 'no match')
-    t.equal(card.format('4242424242424242'), '4242 4242 4242 4242', 'visa')
-    t.equal(card.format('4242424242424242', '-'), '4242-4242-4242-4242', 'separator')
-    t.end()
+  await t.test('format', () => {
+    assert.equal(card.format('5'), '5', 'no match')
+    assert.equal(card.format('4242424242424242'), '4242 4242 4242 4242', 'visa')
+    assert.equal(card.format('4242424242424242', '-'), '4242-4242-4242-4242', 'separator')
   })
 
-  t.test('type', function (t) {
-    t.equal(card.type('4242424242424242'), 'Visa', 'visa')
-    t.equal(card.type('5555555555554444'), 'Mastercard', 'mc')
-    t.equal(card.type('378282246310005'), 'American Express', 'amex')
+  await t.test('type', () => {
+    assert.equal(card.type('4242424242424242'), 'Visa', 'visa')
+    assert.equal(card.type('5555555555554444'), 'Mastercard', 'mc')
+    assert.equal(card.type('378282246310005'), 'American Express', 'amex')
 
-    t.equal(card.type('42', true), 'Visa', 'visa eager')
-    t.equal(card.type('55', true), 'Mastercard', 'mc eager')
-    t.equal(card.type('37', true), 'American Express', 'amex eager')
+    assert.equal(card.type('42', true), 'Visa', 'visa eager')
+    assert.equal(card.type('55', true), 'Mastercard', 'mc eager')
+    assert.equal(card.type('37', true), 'American Express', 'amex eager')
 
-    t.notOk(card.type('123'), 'no match')
-
-    t.end()
+    assert.ok(!card.type('123'), 'no match')
   })
 
-  t.test('isValid', function (t) {
-    t.ok(card.isValid('4242424242424242'))
-    t.ok(card.isValid('5555555555554444'))
-    t.ok(card.isValid('378282246310005'))
-    t.notOk(card.isValid('42'))
+  await t.test('isValid', () => {
+    assert.ok(card.isValid('4242424242424242'))
+    assert.ok(card.isValid('5555555555554444'))
+    assert.ok(card.isValid('378282246310005'))
+    assert.ok(!card.isValid('42'))
 
-    t.ok(card.isValid('4242424242424242', 'Visa'), 'visa')
-    t.notOk(card.isValid('4242424242424242', 'American Express'), 'amex invalid')
-    t.notOk(card.isValid('4242424242424242', 'Mastercard', 'mc invalid'))
-    t.ok(card.isValid('378282246310005', 'American Express'), 'amex valid')
+    assert.ok(card.isValid('4242424242424242', 'Visa'), 'visa')
+    assert.ok(!card.isValid('4242424242424242', 'American Express'), 'amex invalid')
+    assert.ok(!card.isValid('4242424242424242', 'Mastercard'), 'mc invalid')
+    assert.ok(card.isValid('378282246310005', 'American Express'), 'amex valid')
 
     const unionPay = '6240008631401142'
-    t.notOk(card.luhn(unionPay))
-    t.ok(card.isValid(unionPay, 'UnionPay'), 'union pay skips luhn')
-
-    t.end()
+    assert.ok(!card.luhn(unionPay))
+    assert.ok(card.isValid(unionPay, 'UnionPay'), 'union pay skips luhn')
   })
 
-  t.test('custom types', function (t) {
+  await t.test('custom types', () => {
     const customCard = Card([visa])
-    t.ok(customCard.isValid('4242424242424242'), 'visa valid')
-    t.notOk(customCard.isValid('5555555555554444'), 'mc invalid')
-    t.end()
+    assert.ok(customCard.isValid('4242424242424242'), 'visa valid')
+    assert.ok(!customCard.isValid('5555555555554444'), 'mc invalid')
   })
-
-  t.end()
 })

--- a/card.js
+++ b/card.js
@@ -1,9 +1,7 @@
-'use strict'
+import luhn from 'fast-luhn'
+import Types from './types.js'
 
-const luhn = require('fast-luhn')
-const Types = require('./types')
-
-module.exports = Card
+export default Card
 
 function Card (data) {
   const types = Types(data)

--- a/cvc-test.js
+++ b/cvc-test.js
@@ -1,32 +1,29 @@
-'use strict'
-
-const test = require('tape')
-const Cvc = require('./cvc')
-const types = require('creditcards-types')
-const visa = require('creditcards-types/types/visa')
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import types from 'creditcards-types'
+import visa from 'creditcards-types/types/visa'
+import Cvc from './cvc.js'
 
 const cvc = Cvc(types)
 
-test('cvc', function (t) {
-  t.ok(cvc.isValid('123'))
-  t.ok(cvc.isValid('1234'))
-  t.notOk(cvc.isValid('12'))
-  t.notOk(cvc.isValid('12345'))
+test('cvc', () => {
+  assert.ok(cvc.isValid('123'))
+  assert.ok(cvc.isValid('1234'))
+  assert.ok(!cvc.isValid('12'))
+  assert.ok(!cvc.isValid('12345'))
 
-  t.ok(cvc.isValid('123', 'Visa'))
-  t.notOk(cvc.isValid('1234', 'Visa'))
-  t.notOk(cvc.isValid('123', 'American Express'))
-  t.ok(cvc.isValid('1234', 'American Express'))
+  assert.ok(cvc.isValid('123', 'Visa'))
+  assert.ok(!cvc.isValid('1234', 'Visa'))
+  assert.ok(!cvc.isValid('123', 'American Express'))
+  assert.ok(cvc.isValid('1234', 'American Express'))
 
-  t.notOk(cvc.isValid(123))
+  assert.ok(!cvc.isValid(123))
 
   const visaCvc = Cvc([visa])
 
-  t.ok(visaCvc.isValid('123'))
-  t.notOk(visaCvc.isValid('1234'), 'no type matches length')
-  t.throws(function () {
+  assert.ok(visaCvc.isValid('123'))
+  assert.ok(!visaCvc.isValid('1234'), 'no type matches length')
+  assert.throws(function () {
     visaCvc.isValid('1234', 'American Express')
   }, /no type found/i)
-
-  t.end()
 })

--- a/cvc.js
+++ b/cvc.js
@@ -1,9 +1,8 @@
-'use strict'
+import Types from './types.js'
 
-const Types = require('./types')
 const cvcRegex = /^\d{3,4}$/
 
-module.exports = Cvc
+export default Cvc
 
 function Cvc (data) {
   const types = Types(data)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,13 @@
+import js from '@eslint/js'
+import globals from 'globals'
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: { ...globals.node }
+    }
+  }
+]

--- a/expiration-test.js
+++ b/expiration-test.js
@@ -1,42 +1,36 @@
-'use strict'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import * as expiration from './expiration.js'
 
-const test = require('tape')
-const expiration = require('./expiration')
-
-test('expiration', function (t) {
-  t.ok(expiration.isPast(
+test('expiration', async (t) => {
+  assert.ok(expiration.isPast(
     new Date().getMonth(),
     new Date().getFullYear()
   ))
-  t.notOk(expiration.isPast(
+  assert.ok(!expiration.isPast(
     new Date().getMonth() + 1,
     new Date().getFullYear()
   ))
 
-  t.test('month', function (t) {
+  await t.test('month', () => {
     const month = expiration.month
-    t.equal(month.parse('12'), 12)
-    t.end()
+    assert.equal(month.parse('12'), 12)
   })
 
-  t.test('year', function (t) {
+  await t.test('year', () => {
     const year = expiration.year
 
-    t.equal(year.format('2012'), '2012')
-    t.equal(year.format(2012), '2012')
-    t.equal(year.format(2014, true), '14')
-    t.equal(year.format(2000, true), '00')
+    assert.equal(year.format('2012'), '2012')
+    assert.equal(year.format(2012), '2012')
+    assert.equal(year.format(2014, true), '14')
+    assert.equal(year.format(2000, true), '00')
 
-    t.ok(year.isValid(2015))
-    t.notOk(year.isValid('2015'))
-    t.notOk(year.isValid(2015.5))
+    assert.ok(year.isValid(2015))
+    assert.ok(!year.isValid('2015'))
+    assert.ok(!year.isValid(2015.5))
 
-    t.notOk(year.isPast(new Date().getFullYear()))
-    t.notOk(year.isPast(), 2100)
-    t.ok(year.isPast(2000))
-
-    t.end()
+    assert.ok(!year.isPast(new Date().getFullYear()))
+    assert.ok(!year.isPast(2100))
+    assert.ok(year.isPast(2000))
   })
-
-  t.end()
 })

--- a/expiration.js
+++ b/expiration.js
@@ -1,25 +1,21 @@
-'use strict'
+import isValidMonth from 'is-valid-month'
+import parseIntStrict from 'parse-int'
+import parseYear from 'parse-year'
 
-const isValidMonth = require('is-valid-month')
-const parseIntStrict = require('parse-int')
-const parseYear = require('parse-year')
-
-module.exports = {
-  isPast: isPast,
-  month: {
-    parse: parseMonth,
-    isValid: isValidMonth
-  },
-  year: {
-    parse: parseYear,
-    format: formatExpYear,
-    isValid: isExpYearValid,
-    isPast: isExpYearPast
-  }
+export function isPast (month, year) {
+  return Date.now() >= new Date(year, month)
 }
 
-function isPast (month, year) {
-  return Date.now() >= new Date(year, month)
+export const month = {
+  parse: parseMonth,
+  isValid: isValidMonth
+}
+
+export const year = {
+  parse: parseYear,
+  format: formatExpYear,
+  isValid: isExpYearValid,
+  isPast: isExpYearPast
 }
 
 function parseMonth (month) {

--- a/index.js
+++ b/index.js
@@ -1,17 +1,18 @@
-'use strict'
+import Card from './card.js'
+import Cvc from './cvc.js'
+import * as expiration from './expiration.js'
+import types from 'creditcards-types'
 
-const types = require('creditcards-types')
-const Card = require('./card')
-const Cvc = require('./cvc')
-const expiration = require('./expiration')
-
-module.exports = withTypes(types)
-module.exports.withTypes = withTypes
-
-function withTypes (types) {
+export function withTypes (types) {
   return {
     card: Card(types),
     cvc: Cvc(types),
-    expiration: expiration
+    expiration
   }
 }
+
+const defaults = withTypes(types)
+
+export const card = defaults.card
+export const cvc = defaults.cvc
+export { expiration }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "creditcards",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Utility methods for formatting and validating credit cards",
-  "main": "index.js",
+  "type": "module",
+  "exports": {
+    ".": { "types": "./index.d.ts", "default": "./index.js" }
+  },
   "scripts": {
-    "test": "standard && tape *.js && tsd"
+    "test": "eslint . && node --test && tsd"
   },
   "repository": {
     "type": "git",
@@ -23,12 +26,13 @@
   },
   "homepage": "https://github.com/bendrucker/creditcards",
   "devDependencies": {
-    "standard": "^17.0.0",
-    "tape": "^5.0.1",
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.5.0",
+    "globals": "^17.6.0",
     "tsd": "^0.33.0"
   },
   "dependencies": {
-    "creditcards-types": "^4.0.0",
+    "creditcards-types": "^5.0.0",
     "fast-luhn": "^2.0.0",
     "is-valid-month": "^1.0.0",
     "parse-int": "^1.0.3",
@@ -39,6 +43,6 @@
     "*.d.ts"
   ],
   "engines": {
-    "node": ">= 18"
+    "node": ">= 22"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -17,15 +17,16 @@ creditcards exports:
 * `expiration`
 * `withTypes` (constructs a new copy of the module with custom types)
 
-You can also require modules individually. This is particularly useful if you wish to pass in custom types. `card` and `cvc` each export a function that accepts an array of card types [(see `creditcards-types`)](https://github.com/bendrucker/creditcards-types). `expiration` returns an object.
+To validate against a custom set of card types, pass an array of types [(see `creditcards-types`)](https://github.com/bendrucker/creditcards-types) to `withTypes`. It returns `card`, `cvc`, and `expiration` bound to those types.
 
 ```js
-const Card = require('creditcards/card')
-const card = Card([visa])
+import { withTypes, expiration } from 'creditcards'
+import visa from 'creditcards-types/types/visa'
+
+const { card } = withTypes([visa])
 card.isValid('4242424242424242')
 // => true
 
-const expiration = require('creditcards/expiration')
 expiration.isPast(10, 2010)
 // => true
 ```

--- a/test.js
+++ b/test.js
@@ -1,15 +1,12 @@
-'use strict'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import amex from 'creditcards-types/types/american-express'
+import { card, cvc, expiration, withTypes } from './index.js'
 
-const test = require('tape')
-const amex = require('creditcards-types/types/american-express')
-const creditcards = require('./')
+test('main', () => {
+  assert.ok(card.isValid('4242424242424242'))
+  assert.ok(cvc.isValid('123'))
+  assert.ok(expiration.isPast(10, 2010))
 
-test('main', function (t) {
-  t.ok(creditcards.card.isValid('4242424242424242'))
-  t.ok(creditcards.cvc.isValid('123'))
-  t.ok(creditcards.expiration.isPast(10, 2010))
-
-  t.notOk(creditcards.withTypes([amex]).card.isValid('4242424242424242'))
-
-  t.end()
+  assert.ok(!withTypes([amex]).card.isValid('4242424242424242'))
 })

--- a/types.js
+++ b/types.js
@@ -1,9 +1,7 @@
-'use strict'
+import defaults from 'creditcards-types'
 
-const defaults = require('creditcards-types')
-
-module.exports = CardTypes
-module.exports.defaults = defaults
+export default CardTypes
+export { defaults }
 
 function CardTypes (types) {
   const map = types.reduce(function (acc, type) {


### PR DESCRIPTION
Converts `creditcards` to ESM-only and aligns the runtime with the existing type declarations. Coordinated breaking release with `creditcards-types@5.0.0`, which must be published first.

## Breaking changes

- ESM-only. `require('creditcards')` no longer works.
- The runtime now uses **named exports** (`card`, `cvc`, `expiration`, `withTypes`) instead of a single `module.exports` object, matching what `index.d.ts` already declared. Consumers move from `require('creditcards').card` to `import { card } from 'creditcards'`.
- Deep imports (`creditcards/card`, `creditcards/expiration`) are removed. The `exports` map exposes only the package root. Pass custom types through `withTypes([...])` instead.
- Node floor raised to `>= 22`.
- Depends on `creditcards-types@^5`.

## Tooling

- Tests run on `node:test` + `node:assert/strict` (dropped `tape`).
- Lint is plain ESLint 10 with `@eslint/js` recommended (dropped `standard`, which pinned ESLint 8). Correctness-only baseline; `.editorconfig` already covers whitespace.
- CI matrix is Node 22 and 24.

The `parse-int` / `parse-year` / `is-valid-month` / `fast-luhn` runtime deps stay as-is. ESM imports them cleanly, and `Number.parseInt` is not equivalent to `parse-int`'s strict parse, so inlining would risk behavior changes.

## Testing

`npm test` passes (ESLint, `node --test`, `tsd`). Verified the named-export API and `withTypes` locally against a linked `creditcards-types@5.0.0`.
